### PR TITLE
render once and exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Options:
   -c, --center           Center the clock in the terminal. Overrides manual positioning
   -C, --color <COLOR>    Change the color of the time [default: 2]
   -f, --format <FORMAT>  Change the date format [default: "%F | %Z"]
+  -o, --once             Render the clock once and exit
   -h, --help             Print help (see more with '--help')
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,12 +65,17 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     }
 
     let mut term = Term::new()?;
-    let mut clock = Clock::new(configuration);
+    let mut clock = Clock::new(configuration.clone());
 
     // Draw immediately for responsiveness
     let mut size = term.size()?;
     clock.resize(size);
     clock.reset(&mut term)?;
+
+    // If --once flag is set, just draw and exit
+    if configuration.once {
+        return Ok(());
+    }
 
     while !FINISH.load(Ordering::Relaxed) {
         let mut dirty = false;

--- a/src/view.rs
+++ b/src/view.rs
@@ -20,7 +20,7 @@ use crate::time::Time;
 /// A digital clock for the terminal, inspired by tty-clock.
 ///
 /// Defaults to 12-hour local time, no seconds, in the top left corner.
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 #[clap(name = "tock", about = "A digital clock for the terminal.")]
 pub struct Configuration {
     /// Horizontal 0-indexed position of top-left corner.
@@ -72,6 +72,10 @@ pub struct Configuration {
     /// [0]: https://docs.rs/chrono/0.4.6/chrono/format/strftime/index.html
     #[clap(short, long, default_value = "%F | %Z")]
     format: String,
+
+    /// Render the clock once and exit.
+    #[clap(short = 'o', long)]
+    pub once: bool,
 }
 
 //  H       :   M       :   S


### PR DESCRIPTION
I added the --once option. This is useful because i have a script which renders every few seconds some results of different commands but tock fails because it does not exit. 